### PR TITLE
added ability to hide items in voukoder menu

### DIFF
--- a/Core/EncoderOptionInfo.h
+++ b/Core/EncoderOptionInfo.h
@@ -48,6 +48,7 @@ struct EncoderOptionInfo
 	bool isForced = false;
 	bool isActive = false;
 	bool prependNoIfFalse = false;
+	bool visible = true;
 
 	struct ComboItem
 	{

--- a/Core/OptionResourceUtils.cpp
+++ b/Core/OptionResourceUtils.cpp
@@ -51,6 +51,10 @@ bool OptionResourceUtils::CreateOptionInfo(EncoderOptionInfo &optionInfo, const 
 	if (resource.find("prependNoIfFalse") != resource.end())
 		optionInfo.prependNoIfFalse = resource["prependNoIfFalse"].get<bool>();
 
+	// Optional: Should this item be invisible?
+	if (resource.find("visible") != resource.end())
+		optionInfo.visible = resource["visible"].get<bool>();
+
 	// Get the control type
 	std::string type = resource["control"]["type"].get<std::string>();
 

--- a/Core/wxOptionEditor.cpp
+++ b/Core/wxOptionEditor.cpp
@@ -138,6 +138,10 @@ void wxOptionEditor::Configure(EncoderInfo encoderInfo, OptionContainer options)
 		// Add all options to the group
 		for (const EncoderOptionInfo &optionInfo : group.options)
 		{
+			//skip this item if it is flagged as invisible
+			if (!optionInfo.visible)
+				continue;
+
 			wxOptionProperty *optionProperty = new wxOptionProperty(optionInfo);
 			m_propertyGrid->AppendIn(category, optionProperty);
 


### PR DESCRIPTION
Ability to hide items in the Voukoder options window. Could be helpful if e.g parameters are broken or unstable. This way they can be flagged with "visible" = false in the .json file and hasn't to be removed completely.