### PR TITLE
Changed libx264-5.json, further test needed

### DIFF
--- a/Core/resources/encoders/libx264.json
+++ b/Core/resources/encoders/libx264.json
@@ -11,7 +11,7 @@
       "description": "by iAvoe. The down side is libx264 does not have fgo (film grain optimization) available, only rdo (rate distorsion optimization)",
       "options": {
         "_pixelFormat": "yuv420p",
-        "preset": "meduim",
+        "preset": "medium",
 
         "me": "umh",
         "subme": "10",
@@ -43,11 +43,11 @@
       }
     },
     {
-     "name": "4:2:0 General purpose, 8-10bit projects (Recommended)",
+     "name": "4:2:0 General purpose, 10bit projects (Recommended)",
      "description": "by iAvoe. There are no option listed for bit-depth, and the implementation of _pixelFormat does not relate to bit depth; may needs a test on 10bit projects",
      "options": {
        "_pixelFormat": "yuv420p10le",
-       "preset": "meduim",
+       "preset": "medium",
 
        "me": "umh",
        "subme": "10",
@@ -115,7 +115,7 @@
      }
     },
     {
-     "name": "4:4:4 General purpose, 8-10bit projects (ProRes alternative)",
+     "name": "4:4:4 General purpose, 10bit projects (ProRes alternative)",
      "description": "by iAvoe",
      "options": {
        "_pixelFormat": "yuv444p10le",
@@ -191,7 +191,7 @@
         }
    },
    {
-      "name": "4:2:0 Lossless, 8-10bit projects",
+      "name": "4:2:0 Lossless, 10bit projects",
       "description": "by iAvoe",
       "options": {
         "_pixelFormat": "yuv420p10le",
@@ -206,7 +206,7 @@
       }
    },
    {
-      "name": "4:4:4 Lossless, 8-10bit projects",
+      "name": "4:4:4 Lossless, 10bit projects",
       "description": "by iAvoe",
       "options": {
         "_pixelFormat": "yuv444p10le",
@@ -293,7 +293,7 @@
         }
    },
    {
-      "name": "4:4:4 High compression, 8-10bit projects (Very slow)",
+      "name": "4:4:4 High compression, 10bit projects (Very slow)",
       "description": "by iAvoe",
       "options": {
         "_pixelFormat": "yuv444p10le",

--- a/Core/resources/encoders/libx264.json
+++ b/Core/resources/encoders/libx264.json
@@ -7,40 +7,156 @@
   },
   "presets": [
     {
-      "name": "General purpose (Recommended)",
-      "description": "Thanks to iAvoe",
+      "name": "4:2:0 General purpose, 8bit projects (Recommended if you are not sure)",
+      "description": "by iAvoe. The down side is libx264 does not have fgo (film grain optimization) available, only rdo (rate distorsion optimization)",
       "options": {
         "_pixelFormat": "yuv420p",
-        "rc": "crf",
-        "preset": "medium",
+        "preset": "meduim",
+
         "me": "umh",
         "subme": "10",
         "merange": "32",
+        "no-fast-pskip": "1",
+        "no-chroma-me": "1",
+        "direct": "auto",
+        "weightb": "1",
+
         "keyint": "480",
         "min-keyint": "3",
         "bframes": "11",
         "b-adapt": "2",
         "ref": "3",
-        "no-fast-pskip": "1",
-        "direct": "auto",
+        "rc-lookahead": "110",
+
+        "rc": "crf",
         "crf": "17",
-        "qpmax": "22",
-        "rc-lookahead": "180",
-        "aq-mode": "2",
-        "aq-strength": "0.7",
+        "qpmax": "24",
+        "chroma-qp-offest": "-2",
+
+        "aq-mode": "3",
+        "aq-strength": "0.8",
         "trellis": "2",
+
         "deblock": "0:0",
-        "psr-rd": "0.7:0.2",
-        "nr": "10"
+        "psr-rd": "0.77:0.22",
+        "nr": "8"
       }
     },
     {
-      "name": "General purpose (Fast)",
-      "description": "Thanks to iAvoe",
+     "name": "4:2:0 General purpose, 8-10bit projects (Recommended)",
+     "description": "by iAvoe. There are no option listed for bit-depth, and the implementation of _pixelFormat does not relate to bit depth; may needs a test on 10bit projects",
+     "options": {
+       "_pixelFormat": "yuv420p10le",
+       "preset": "meduim",
+
+       "me": "umh",
+       "subme": "10",
+       "merange": "32",
+       "no-fast-pskip": "1",
+       "no-chroma-me": "1",
+       "direct": "auto",
+       "weightb": "1",
+
+       "keyint": "480",
+       "min-keyint": "3",
+       "bframes": "11",
+       "b-adapt": "2",
+       "ref": "3",
+       "rc-lookahead": "110",
+
+       "rc": "crf",
+       "crf": "17",
+       "qpmax": "24",
+       "chroma-qp-offest": "-2",
+
+       "aq-mode": "3",
+       "aq-strength": "0.8",
+       "trellis": "2",
+
+       "deblock": "0:0",
+       "psr-rd": "0.77:0.22",
+       "nr": "8"
+     }
+    },
+    {
+     "name": "4:4:4 General purpose, 8bit projects (Render & reuse)",
+     "description": "by iAvoe",
+     "options": {
+       "_pixelFormat": "yuv444p",
+       "preset": "slow",
+
+       "me": "umh",
+       "subme": "10",
+       "merange": "32",
+       "no-fast-pskip": "1",
+       "no-chroma-me": "1",
+       "direct": "auto",
+       "weightb": "1",
+
+       "keyint": "480",
+       "min-keyint": "3",
+       "bframes": "11",
+       "b-adapt": "2",
+       "ref": "3",
+       "rc-lookahead": "110",
+
+       "rc": "crf",
+       "crf": "17",
+       "qpmax": "24",
+       "chroma-qp-offest": "-2",
+
+       "aq-mode": "3",
+       "aq-strength": "0.9",
+       "trellis": "2",
+
+       "deblock": "0:0",
+       "psr-rd": "0.77:0.22",
+       "nr": "8"
+     }
+    },
+    {
+     "name": "4:4:4 General purpose, 8-10bit projects (ProRes alternative)",
+     "description": "by iAvoe",
+     "options": {
+       "_pixelFormat": "yuv444p10le",
+       "preset": "slow",
+
+       "me": "umh",
+       "subme": "10",
+       "merange": "32",
+       "no-fast-pskip": "1",
+       "no-chroma-me": "1",
+       "direct": "auto",
+       "weightb": "1",
+
+       "keyint": "480",
+       "min-keyint": "3",
+       "bframes": "11",
+       "b-adapt": "2",
+       "ref": "3",
+       "rc-lookahead": "110",
+
+       "rc": "crf",
+       "crf": "17",
+       "qpmax": "24",
+       "chroma-qp-offest": "-2",
+
+       "aq-mode": "3",
+       "aq-strength": "0.9",
+       "trellis": "2",
+
+       "deblock": "0:0",
+       "psr-rd": "0.77:0.22",
+       "nr": "8"
+     }
+    },
+    {
+      "name": "4:2:0 General purpose, 8bit projects (Fast)",
+      "description": "by iAvoe",
       "options": {
         "_pixelFormat": "yuv420p",
         "rc": "crf",
-        "preset": "medium",
+        "preset": "fast",
         "me": "hex",
         "subme": "8",
         "merange": "16",
@@ -51,17 +167,17 @@
         "ref": "3",
         "scenecut ": "33",
         "crf": "17",
-        "qpmax": "22",
-        "rc-lookahead": "120",
+        "qpmax": "24",
+        "rc-lookahead": "100",
         "aq-mode": "3",
         "aq-strength": "0.8",
         "deblock": "1:0",
         "psr-rd": "0.7:0.3"
       }
-    },
-    {
-      "name": "Lossless",
-      "description": "Thanks to iAvoe",
+   },
+   {
+      "name": "4:2:0 Lossless, 8bit projects",
+      "description": "by iAvoe",
       "options": {
         "_pixelFormat": "yuv420p",
         "rc": "cqp",
@@ -72,112 +188,176 @@
         "ref": "3",
         "qp": "0",
         "chroma-qp-offest": "-3"
+        }
+   },
+   {
+      "name": "4:2:0 Lossless, 8-10bit projects",
+      "description": "by iAvoe",
+      "options": {
+        "_pixelFormat": "yuv420p10le",
+        "rc": "cqp",
+        "preset": "medium",
+        "keyint": "180",
+        "min-keyint": "180",
+        "bframes": "6",
+        "ref": "3",
+        "qp": "0",
+        "chroma-qp-offest": "-3"
       }
-    },
-    {
-      "name": "Good quality, high compression (very slow)",
-      "description": "Thanks to iAvoe",
+   },
+   {
+      "name": "4:4:4 Lossless, 8-10bit projects",
+      "description": "by iAvoe",
+      "options": {
+        "_pixelFormat": "yuv444p10le",
+        "rc": "cqp",
+        "preset": "medium",
+        "keyint": "180",
+        "min-keyint": "180",
+        "bframes": "6",
+        "ref": "3",
+        "qp": "0",
+        "chroma-qp-offest": "-3"
+        }
+   },
+   {
+      "name": "4:2:0 High compression, 8bit projects (Very slow)",
+      "description": "by iAvoe",
       "options": {
         "_pixelFormat": "yuv420p",
-        "rc": "crf",
-        "crf": "19",
-        "preset": "medium",
+        "preset": "veryslow",
+        "tune": "grain",
+ 
         "me": "esa",
         "subme": "10",
-        "merange": "52",
-        "keyint": "600",
-        "min-keyint": "1",
-        "bframes": "13",
-        "b-adapt": "2",
-        "ref": "3",
+        "merange": "48",
         "no-fast-pskip": "1",
         "direct": "auto",
-        "scenecut": "35",
-        "ipratio": "1.5",
-        "qpmin": "13",
-        "rc-lookahead": "180",
-        "aq-mode": "3",
-        "aq-strength": "0.8",
-        "trellis": "2",
-        "nr": "20"
-      }
-    },
-    {
-      "name": "High quality, high compression (very slow)",
-      "description": "Thanks to iAvoe",
-      "options": {
-        "_pixelFormat": "yuv420p",
-        "rc": "crf",
-        "crf": "17",
-        "preset": "medium",
-        "me": "esa",
-        "subme": "10",
-        "merange": "52",
-        "keyint": "360",
-        "min-keyint": "1",
-        "bframes": "14",
-        "b-adapt": "2",
-        "ref": "3",
-        "no-fast-pskip": "1",
-        "direct": "auto",
-        "qpmax": "24",
-        "rc-lookahead": "180",
-        "aq-mode": "2",
-        "aq-strength": "0.7",
-        "trellis": "2",
-        "deblock": "0:0",
-        "no-psy": "1",
-        "nr": "10"
-      }
-    },
-    {
-      "name": "Maximum Useful Cost Possible, good quality",
-      "description": "Thanks to iAvoe",
-      "options": {
-        "_pixelFormat": "yuv420p",
-        "rc": "crf",
-        "crf": "18",
-        "preset": "medium",
-        "me": "esa",
-        "subme": "10",
-        "merange": "56",
-        "keyint": "300",
+        "weightb": "1",
+ 
+        "keyint": "480",
         "min-keyint": "1",
         "bframes": "16",
         "b-adapt": "2",
         "ref": "3",
+        "rc-lookahead": "110",
+ 
+        "rc": "crf",
+        "crf": "19",
+        "qpmin": "12",
+        "chroma-qp-offest": "-4",
+ 
+        "aq-mode": "3",
+        "aq-strength": "0.7",
+        "trellis": "2",
+ 
+        "deblock": "0:0",
+        "psr-rd": "0.77:0.22",
+        "nr": "8"
+        }
+   },
+   {
+      "name": "4:4:4 High compression, 8bit projects (Very slow)",
+      "description": "by iAvoe",
+      "options": {
+        "_pixelFormat": "yuv444p",
+        "preset": "veryslow",
+        "tune": "grain",
+
+        "me": "esa",
+        "subme": "10",
+        "merange": "48",
+        "no-fast-pskip": "1",
+        "direct": "auto",
+        "weightb": "1",
+
+        "keyint": "480",
+        "min-keyint": "1",
+        "bframes": "16",
+        "b-adapt": "2",
+        "ref": "3",
+        "rc-lookahead": "110",
+
+        "rc": "crf",
+        "crf": "19",
+        "qpmin": "12",
+        "chroma-qp-offest": "-4",
+
+        "aq-mode": "3",
+        "aq-strength": "0.7",
+        "trellis": "2",
+
+        "deblock": "0:0",
+        "psr-rd": "0.77:0.22",
+        "nr": "8"
+        }
+   },
+   {
+      "name": "4:4:4 High compression, 8-10bit projects (Very slow)",
+      "description": "by iAvoe",
+      "options": {
+        "_pixelFormat": "yuv444p10le",
+        "preset": "veryslow",
+        "tune": "grain",
+ 
+        "me": "esa",
+        "subme": "10",
+        "merange": "48",
+        "no-fast-pskip": "1",
+        "direct": "auto",
+        "weightb": "1",
+ 
+        "keyint": "480",
+        "min-keyint": "1",
+        "bframes": "16",
+        "b-adapt": "2",
+        "ref": "3",
+        "rc-lookahead": "110",
+ 
+        "rc": "crf",
+        "crf": "19",
+        "qpmin": "12",
+        "chroma-qp-offest": "-4",
+ 
+        "aq-mode": "3",
+        "aq-strength": "0.7",
+        "trellis": "2",
+ 
+        "deblock": "0:0",
+        "psr-rd": "0.77:0.22",
+        "nr": "8"
+        }
+   },
+   {
+      "name": "4:4:4 Encode speed benchmark & stability stress test",
+      "description": "by iAvoe. Lowered output quality to make sure people not using this",
+      "options": {
+        "_pixelFormat": "yuv444p",
+        "rc": "crf",
+        "crf": "28",
+        "preset": "placebo",
+        "me": "tesa",
+        "subme": "10",
+        "merange": "128",
+        "keyint": "300",
+        "min-keyint": "1",
+        "bframes": "16",
+        "b-adapt": "2",
+        "ref": "16",
         "no-fast-pskip": "1",
         "direct": "auto",
         "pbratio": "1.5",
-        "qpmax": "24",
-        "rc-lookahead": "240",
+        "rc-lookahead": "220",
         "chroma-qp-offset": "-2",
-        "vbv-maxrate": "8000",
-        "aq-mode": "2",
-        "aq-strength": "0.7",
+        "vbv-bufsize": "15000",
+        "vbv-maxrate": "11000",
+        "aq-mode": "3",
+        "psy-rd": "2:2",
         "trellis": "2",
-        "deblock": "0:0",
-        "no-psy": "1",
-        "nr": "20"
-      }
-    },
-    {
-      "name": "Manual Quality, unknown compression, very fast",
-      "description": "Thanks to iAvoe",
-      "options": {
-        "_pixelFormat": "yuv420p",
-        "rc": "cqp",
-        "qp": "18",
-        "preset": "medium",
-        "keyint": "180",
-        "min-keyint": "1",
-        "bframes": "6",
-        "ref": "3",
-        "scenecut": "33",
-        "deblock": "0:-1",
-        "psr-rd": "0.7:0.53"
-      }
-    }
+        "deblock": "2:2",
+        "nr": "8"
+        }
+   }
   ],
   "parameterGroups": {
     "x264-params": [

--- a/Core/resources/encoders/libx265.json
+++ b/Core/resources/encoders/libx265.json
@@ -2,39 +2,710 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "libx265",
   "name": "HEVC (x265)",
-  "defaults": {},
+  "defaults": {
+   "description": "1.Some libx265-s are missing the option: allow-non-conformance, make sure this parameter exists, otherwise encoder may refuse to start. 2.Default parameters may collide with lossless parameters, and if so they need to be moved to presets",
+   "ctu": "64",
+   "ref": "3",
+   "hash": "2",
+   "preset": "slow",
+   "no-open-gop": "1",
+   "allow-non-conformance": "1",
+   "opt-qp-pps": "1",
+   "opt-ref-list-length-pps": "1"
+  },
   "presets": [
-    {
-      "name": "Good quality (Recommended)",
-      "description": "",
+   {
+      "name": "4:2:0 General purpose, 8bit projects (Recommended if you are not sure)",
+      "description": "by iAvoe, require x265 v3.5 since some parameter names are changed; or new parameters added/deleted",
       "options": {
         "_pixelFormat": "yuv420p",
+        "min-cu-size": "16",
+        "limit-tu": "1",
+        "tu-intra-depth": "2",
+        "tu-inter-depth": "2",
+
+        "me": "umh",
+        "subme": "5",
+        "merange": "48",
+        "rskip": "1",
+        "weightb": "1",
+        
+        "early-skip": "1",
+        "max-merge": "2",
+        "min-keyint": "5",
+        "fades": "1",
+        "bframes": "11",
+        "b-adapt": "2",
+        "radl": "2",
+        "fast-intra": "1",
+
         "_strategy": "crf",
         "crf": "19.0",
-        "preset": "medium",
-        "profile": "main"
-      }
-    },
-    {
-      "name": "High quality",
-      "description": "",
+        "crqpoffs": "-3",
+        "cbqpoffs": "-1",
+
+        "aq-mode": "3",
+        "aq-motion": "1",
+        "qg-size": "16",
+
+        "rd": "3",
+        "rdpenalty": "1",
+        "splitrd-skip": "1",
+        "rdoq-level": "1",
+        "limit-modes": "1",
+        "rect": "1",
+        "tskip-fast": "1",
+
+        "limit-sao": "1",
+        "sao-non-deblock": "1"
+        }
+   },
+      {
+      "name": "4:2:0 General purpose, 8-10bit projects (Recommended)",
+      "description": "by iAvoe, require x265 v3.5 since some parameter names are changed; or new parameters added/deleted",
       "options": {
-        "_pixelFormat": "yuv420p",
+        "_pixelFormat": "yuv420p10le",
+        "min-cu-size": "16",
+        "limit-tu": "1",
+        "tu-intra-depth": "2",
+        "tu-inter-depth": "2",
+ 
+        "me": "umh",
+        "subme": "5",
+        "merange": "48",
+        "rskip": "1",
+        "weightb": "1",
+        
+        "early-skip": "1",
+        "max-merge": "2",
+        "min-keyint": "5",
+        "fades": "1",
+        "bframes": "11",
+        "b-adapt": "2",
+        "radl": "2",
+        "fast-intra": "1",
+
         "_strategy": "crf",
-        "crf": "17.0",
-        "preset": "medium",
-        "profile": "main"
+        "crf": "19.0",
+        "crqpoffs": "-3",
+        "cbqpoffs": "-1",
+
+        "aq-mode": "3",
+        "aq-motion": "1",
+        "qg-size": "16",
+
+        "rd": "3",
+        "rdpenalty": "1",
+        "splitrd-skip": "1",
+        "rdoq-level": "1",
+        "limit-modes": "1",
+        "rect": "1",
+        "tskip-fast": "1",
+
+        "limit-sao": "1",
+        "sao-non-deblock": "1"
+        }
+   },
+   {
+      "name": "4:4:4 General purpose, 8bit projects (Render & reuse)",
+      "description": "by iAvoe",
+      "options": {
+        "_pixelFormat": "yuv444p",
+        "min-cu-size": "16",
+        "limit-tu": "1",
+        "tu-intra-depth": "2",
+        "tu-inter-depth": "2",
+
+        "me": "umh",
+        "subme": "5",
+        "merange": "48",
+        "rskip": "1",
+        "weightb": "1",
+      
+        "early-skip": "1",
+        "max-merge": "2",
+        "min-keyint": "5",
+        "fades": "1",
+        "bframes": "11",
+        "b-adapt": "2",
+        "radl": "2",
+        "fast-intra": "1",
+
+        "_strategy": "crf",
+        "crf": "19.0",
+        "crqpoffs": "-3",
+        "cbqpoffs": "-1",
+
+        "aq-mode": "3",
+        "aq-motion": "1",
+        "qg-size": "16",
+
+        "rd": "3",
+        "rdpenalty": "1",
+        "splitrd-skip": "1",
+        "rdoq-level": "1",
+        "limit-modes": "1",
+        "rect": "1",
+        "tskip-fast": "1",
+
+        "limit-sao": "1",
+        "sao-non-deblock": "1"
+        }
+   },
+   {
+      "name": "4:4:4 General purpose, 8-10bit projects (Render & reuse)",
+      "description": "by iAvoe",
+      "options": {
+        "_pixelFormat": "yuv444p10le",
+        "min-cu-size": "16",
+        "limit-tu": "1",
+        "tu-intra-depth": "2",
+        "tu-inter-depth": "2",
+
+        "me": "umh",
+        "subme": "5",
+        "merange": "48",
+        "rskip": "1",
+        "weightb": "1",
+      
+        "early-skip": "1",
+        "max-merge": "2",
+        "min-keyint": "5",
+        "fades": "1",
+        "bframes": "11",
+        "b-adapt": "2",
+        "radl": "2",
+        "fast-intra": "1",
+
+        "_strategy": "crf",
+        "crf": "19.0",
+        "crqpoffs": "-3",
+        "cbqpoffs": "-1",
+
+        "aq-mode": "3",
+        "aq-motion": "1",
+        "qg-size": "16",
+
+        "rd": "3",
+        "rdpenalty": "1",
+        "splitrd-skip": "1",
+        "rdoq-level": "1",
+        "limit-modes": "1",
+        "rect": "1",
+        "tskip-fast": "1",
+
+        "limit-sao": "1",
+        "sao-non-deblock": "1"
+        }
+   },
+   {
+      "name": "4:2:0 <40000kbps Lossless, 8-10bit projects",
+      "description": "by iAvoe, If clip is going more than 40000kbps, adjust 'b' to higher rates.",
+      "options": {
+        "_pixelFormat": "yuv420p10le",
+        "_strategy": "abr",
+        "b": "40000",
+        "cu-lossless": "1",
+        "psy-rd": "1:0"
+        }
+   },
+   {
+      "name": "4:4:4 <40000kbps Lossless, 8-10bit projects",
+      "description": "by iAvoe, If clip is going more than 40000kbps, adjust 'b' to higher rates",
+      "options": {
+        "_pixelFormat": "yuv444p10le",
+        "_strategy": "abr",
+        "b": "40000",
+        "cu-lossless": "1",
+        "psy-rd": "1:0"
       }
-    },
-    {
-      "name": "Lossless",
-      "description": "",
+   },
+   {
+      "name": "4:4:4 Scientific lossless, 8-10bit projects",
+      "description": "by iAvoe",
+      "options": {
+        "_pixelFormat": "yuv444p10le",
+        "lossless": "1"
+        }
+   },
+   {
+      "name": "4:2:0 High compression, 8bit projects (Very slow)",
+      "description": "by iAvoe. Missing option: selective-sao, add 'selective-sao 3' at end of this option if libx265 v3.5 gets this option implemented.",
       "options": {
         "_pixelFormat": "yuv420p",
-        "preset": "medium",
-        "lossless": "1"
-      }
-    }
+        "min-cu-size": "16",
+        "limit-tu": "1",
+        "tu-intra-depth": "4",
+        "tu-inter-depth": "4",
+
+        "me": "star",
+        "subme": "5",
+        "merange": "48",
+        "analyze-src-pics": "1",
+        "weightb": "1",
+     
+        "early-skip": "1",
+        "max-merge": "4",
+        "keyint": "480",
+        "min-keyint": "3",
+        "fades": "1",
+        "bframes": "14",
+        "b-adapt": "2",
+        "radl": "3",
+        "no-fast-intra": "1",
+
+        "constrained-intra": "1",
+        "b-intra": "1",
+
+        "_strategy": "crf",
+        "crf": "22",
+        "qpmin": "10",
+        "crqpoffs": "-2",
+
+        "aq-mode": "2",
+        "aq-strength": "0.9",
+        "qg-size": "8",
+
+        "rd": "5",
+        "splitrd-skip": "1",
+        "rdoq-level": "2",
+        "limit-modes": "1",
+        "limit-refs": "0",
+        "no-rskip": "1",
+
+        "rect": "1",
+        "amp": "1",
+        "tskip-fast": "1",
+
+        "psy-rd": "1.6",
+        "rd-refine": "1",
+        "rdpenalty": "1",
+
+        "deblock": "0:0",
+        "limit-sao": "1",
+        "sao-non-deblock": "1"
+        }
+   },
+   {
+      "name": "4:2:0 High compression, 8-10bit projects (Very slow)",
+      "description": "by iAvoe. Missing option: selective-sao, add 'selective-sao 3' at end of this option if libx265 v3.5 gets this option implemented",
+      "options": {
+        "_pixelFormat": "yuv420p10le",
+        "min-cu-size": "16",
+        "limit-tu": "1",
+        "tu-intra-depth": "4",
+        "tu-inter-depth": "4",
+
+        "me": "star",
+        "subme": "5",
+        "merange": "48",
+        "analyze-src-pics": "1",
+        "weightb": "1",
+     
+        "early-skip": "1",
+        "max-merge": "4",
+        "keyint": "480",
+        "min-keyint": "3",
+        "fades": "1",
+        "bframes": "14",
+        "b-adapt": "2",
+        "radl": "3",
+        "no-fast-intra": "1",
+
+        "constrained-intra": "1",
+        "b-intra": "1",
+
+        "_strategy": "crf",
+        "crf": "22",
+        "qpmin": "10",
+        "crqpoffs": "-2",
+
+        "aq-mode": "2",
+        "aq-strength": "0.9",
+        "qg-size": "8",
+
+        "rd": "5",
+        "splitrd-skip": "1",
+        "rdoq-level": "2",
+        "limit-modes": "1",
+        "limit-refs": "0",
+        "no-rskip": "1",
+
+        "rect": "1",
+        "amp": "1",
+        "tskip-fast": "1",
+
+        "psy-rd": "1.6",
+        "rd-refine": "1",
+        "rdpenalty": "1",
+
+        "deblock": "0:0",
+        "limit-sao": "1",
+        "sao-non-deblock": "1"
+        }
+   },
+   {
+      "name": "4:4:4 High compression, 8bit projects (Very slow)",
+      "description": "by iAvoe. Missing option: selective-sao, add 'selective-sao 3' at end of this option if libx265 v3.5 gets this option implemented",
+      "options": {
+        "_pixelFormat": "yuv444p",
+        "min-cu-size": "16",
+        "limit-tu": "1",
+        "tu-intra-depth": "4",
+        "tu-inter-depth": "4",
+
+        "me": "star",
+        "subme": "5",
+        "merange": "48",
+        "analyze-src-pics": "1",
+        "weightb": "1",
+     
+        "early-skip": "1",
+        "max-merge": "4",
+        "keyint": "480",
+        "min-keyint": "3",
+        "fades": "1",
+        "bframes": "14",
+        "b-adapt": "2",
+        "radl": "3",
+        "no-fast-intra": "1",
+
+        "constrained-intra": "1",
+        "b-intra": "1",
+
+        "_strategy": "crf",
+        "crf": "22",
+        "qpmin": "10",
+        "crqpoffs": "-2",
+
+        "aq-mode": "2",
+        "aq-strength": "0.9",
+        "qg-size": "8",
+
+        "rd": "5",
+        "splitrd-skip": "1",
+        "rdoq-level": "2",
+        "limit-modes": "1",
+        "limit-refs": "0",
+        "no-rskip": "1",
+
+        "rect": "1",
+        "amp": "1",
+        "tskip-fast": "1",
+
+        "psy-rd": "1.6",
+        "rd-refine": "1",
+        "rdpenalty": "1",
+
+        "deblock": "0:0",
+        "limit-sao": "1",
+        "sao-non-deblock": "1"
+        }
+     },
+     {
+      "name": "4:4:4 High compression, 8-10bit projects (Very slow)",
+      "description": "by iAvoe. Missing option: selective-sao, add 'selective-sao 3' at end of this option if libx265 v3.5 gets this option implemented",
+      "options": {
+        "_pixelFormat": "yuv444p10le",
+        "min-cu-size": "16",
+        "limit-tu": "1",
+        "tu-intra-depth": "4",
+        "tu-inter-depth": "4",
+
+        "me": "star",
+        "subme": "5",
+        "merange": "48",
+        "analyze-src-pics": "1",
+        "weightb": "1",
+     
+        "early-skip": "1",
+        "max-merge": "4",
+        "keyint": "480",
+        "min-keyint": "3",
+        "fades": "1",
+        "bframes": "14",
+        "b-adapt": "2",
+        "radl": "3",
+        "no-fast-intra": "1",
+
+        "constrained-intra": "1",
+        "b-intra": "1",
+
+        "_strategy": "crf",
+        "crf": "22",
+        "qpmin": "10",
+        "crqpoffs": "-2",
+
+        "aq-mode": "2",
+        "aq-strength": "0.9",
+        "qg-size": "8",
+
+        "rd": "5",
+        "splitrd-skip": "1",
+        "rdoq-level": "2",
+        "limit-modes": "1",
+        "limit-refs": "0",
+        "no-rskip": "1",
+
+        "rect": "1",
+        "amp": "1",
+        "tskip-fast": "1",
+
+        "psy-rd": "1.6",
+        "rd-refine": "1",
+        "rdpenalty": "1",
+
+        "deblock": "0:0",
+        "limit-sao": "1",
+        "sao-non-deblock": "1"
+        }
+   },
+   {
+      "name": "4:2:0 Anime +quality, 8-10bit projects (Very slow)",
+      "description": "by iAvoe",
+      "options": {
+        "_pixelFormat": "yuv420p10le",
+        "min-cu-size": "8",
+        "limit-tu": "1",
+        "tu-intra-depth": "4",
+        "tu-inter-depth": "4",
+
+        "me": "star",
+        "subme": "3",
+        "merange": "48",
+        "analyze-src-pics": "1",
+        "weightb": "1",
+
+        "early-skip": "1",
+        "max-merge": "4",
+        "keyint": "480",
+        "min-keyint": "1",
+        "bframes": "13",
+        "b-adapt": "2",
+        "radl": "2",
+
+        "no-fast-intra": "1",
+        "b-intra": "1",
+
+        "_strategy": "crf",
+        "crf": "20",
+        "crqpoffs": "-3",
+        "cbqpoffs": "-1",
+        "cu-lossless": "1",
+
+        "aq-mode": "3",
+        "aq-strength": "0.7",
+        "qg-size": "8",
+
+        "psy-rdoq": "2.3",
+        "rdoq-level": "2",
+
+        "rd": "5",
+        "rskip": "1",
+        "splitrd-skip": "1",
+        "limit-modes": "1",
+        "limit-refs": "0",
+
+        "rect": "1",
+        "amp": "1",
+
+        "psy-rd": "1.6",
+        "rd-refine": "1",
+        "rdpenalty": "1",
+
+        "deblock": "0:0",
+
+        "limit-sao": "1",
+        "sao-non-deblock": "1",
+        "single-sei": "1"
+        }
+    },
+    {
+      "name": "4:4:4 Anime +quality, 8-10bit projects (Very slow)",
+      "description": "by iAvoe",
+      "options": {
+        "_pixelFormat": "yuv444p10le",
+        "min-cu-size": "8",
+        "limit-tu": "1",
+        "tu-intra-depth": "4",
+        "tu-inter-depth": "4",
+
+        "me": "star",
+        "subme": "3",
+        "merange": "48",
+        "analyze-src-pics": "1",
+        "weightb": "1",
+
+        "early-skip": "1",
+        "max-merge": "4",
+        "keyint": "480",
+        "min-keyint": "1",
+        "bframes": "13",
+        "b-adapt": "2",
+        "radl": "2",
+
+        "no-fast-intra": "1",
+        "b-intra": "1",
+
+        "_strategy": "crf",
+        "crf": "20",
+        "crqpoffs": "-3",
+        "cbqpoffs": "-1",
+        "cu-lossless": "1",
+
+        "aq-mode": "3",
+        "aq-strength": "0.7",
+        "qg-size": "8",
+
+        "psy-rdoq": "2.3",
+        "rdoq-level": "2",
+
+        "rd": "5",
+        "rskip": "1",
+        "splitrd-skip": "1",
+        "limit-modes": "1",
+        "limit-refs": "0",
+
+        "rect": "1",
+        "amp": "1",
+
+        "psy-rd": "1.6",
+        "rd-refine": "1",
+        "rdpenalty": "1",
+
+        "deblock": "0:0",
+
+        "limit-sao": "1",
+        "sao-non-deblock": "1",
+        "single-sei": "1"
+        }
+    },
+    {
+      "name": "4:2:0 Anime BDRip Coldwar, 8-10bit projects (Very slow)",
+      "description": "by iAvoe, an unwritten rule requires 4~5x zoom in dark scene must look very similar to source, Ripper who achieves this gets the most downloads, some compression methods disabled, may confuse the hell out of x264-5 devs. I personally don't like this as well",
+      "options": {
+        "_pixelFormat": "yuv420p10le",
+        "min-cu-size": "8",
+        "limit-tu": "0",
+        "tu-intra-depth": "4",
+        "tu-inter-depth": "4",
+
+        "me": "star",
+        "subme": "3",
+        "merange": "48",
+        "analyze-src-pics": "1",
+        "weightb": "1",
+
+        "early-skip": "1",
+        "max-merge": "4",
+        "keyint": "480",
+        "min-keyint": "1",
+        "fades": "1",
+        "bframes": "13",
+        "b-adapt": "2",
+        "radl": "2",
+        "pbratio": "1.2",
+
+        "no-fast-intra": "1",
+        "b-intra": "1",
+
+        "_strategy": "crf",
+        "crf": "19.5",
+        "crqpoffs": "-5",
+        "cbqpoffs": "-3",
+        "cu-lossless": "1",
+
+        "aq-mode": "3",
+        "aq-strength": "0.7",
+        "qg-size": "8",
+
+        "psy-rdoq": "2.3",
+        "rdoq-level": "2",
+
+        "rd": "5",
+        "rskip": "0",
+        "splitrd-skip": "1",
+        "limit-modes": "1",
+        "limit-refs": "0",
+        "rc-lookahead": "90",
+
+        "rect": "1",
+        "amp": "1",
+        "no-cutree": "1",
+
+        "psy-rd": "1.5",
+        "rd-refine": "1",
+        "rdpenalty": "2",
+
+        "deblock": "0:0",
+
+        "no-sao": "1",
+        "single-sei": "1"
+        }
+    },
+    {
+      "name": "4:4:4 Anime BDRip Coldwar, 8-10bit projects (Very slow)",
+      "description": "by iAvoe",
+      "options": {
+        "_pixelFormat": "yuv444p10le",
+        "min-cu-size": "8",
+        "limit-tu": "0",
+        "tu-intra-depth": "4",
+        "tu-inter-depth": "4",
+
+        "me": "star",
+        "subme": "3",
+        "merange": "48",
+        "analyze-src-pics": "1",
+        "weightb": "1",
+
+        "early-skip": "1",
+        "max-merge": "4",
+        "keyint": "480",
+        "min-keyint": "1",
+        "fades": "1",
+        "bframes": "13",
+        "b-adapt": "2",
+        "radl": "2",
+        "pbratio": "1.2",
+
+        "no-fast-intra": "1",
+        "b-intra": "1",
+
+        "_strategy": "crf",
+        "crf": "19.5",
+        "crqpoffs": "-5",
+        "cbqpoffs": "-3",
+        "cu-lossless": "1",
+
+        "aq-mode": "3",
+        "aq-strength": "0.7",
+        "qg-size": "8",
+
+        "psy-rdoq": "2.3",
+        "rdoq-level": "2",
+
+        "rd": "5",
+        "rskip": "0",
+        "splitrd-skip": "1",
+        "limit-modes": "1",
+        "limit-refs": "0",
+        "rc-lookahead": "90",
+
+        "rect": "1",
+        "amp": "1",
+        "no-cutree": "1",
+
+        "psy-rd": "1.5",
+        "rd-refine": "1",
+        "rdpenalty": "2",
+
+        "deblock": "0:0",
+
+        "no-sao": "1",
+        "single-sei": "1"
+        }
+  }
   ],
   "parameterGroups": {
     "x265-params": [
@@ -1914,8 +2585,8 @@
           }
         },
         {
-          "id": "libx265.motionsearch.merange ",
-          "parameter": "merange ",
+          "id": "libx265.motionsearch.merange",
+          "parameter": "merange",
           "control": {
             "maximum": 32768,
             "minimum": 0,

--- a/Core/resources/encoders/libx265.json
+++ b/Core/resources/encoders/libx265.json
@@ -1629,6 +1629,15 @@
           "prependNoIfFalse": true
         },
         {
+          "id": "libx265.standard.allow-non-conformance",
+          "parameter": "allow-non-conformance",
+          "control": {
+            "type": "boolean",
+            "value": true
+          },
+          "prependNoIfFalse": true
+        },
+        {
           "id": "libx265.standard.strategy",
           "parameter": "_strategy",
           "control": {

--- a/Core/resources/encoders/libx265.json
+++ b/Core/resources/encoders/libx265.json
@@ -2,23 +2,17 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "libx265",
   "name": "HEVC (x265)",
-  "defaults": {
-   "description": "1.Some libx265-s are missing the option: allow-non-conformance, make sure this parameter exists, otherwise encoder may refuse to start. 2.Default parameters may collide with lossless parameters, and if so they need to be moved to presets",
-   "ctu": "64",
-   "ref": "3",
-   "hash": "2",
-   "preset": "slow",
-   "no-open-gop": "1",
-   "allow-non-conformance": "1",
-   "opt-qp-pps": "1",
-   "opt-ref-list-length-pps": "1"
-  },
+  "defaults": {},
   "presets": [
    {
       "name": "4:2:0 General purpose, 8bit projects (Recommended if you are not sure)",
       "description": "by iAvoe, require x265 v3.5 since some parameter names are changed; or new parameters added/deleted",
       "options": {
         "_pixelFormat": "yuv420p",
+        "preset": "slow",
+        "ctu": "64",
+        "ref": "3",
+        "hash": "2",
         "min-cu-size": "16",
         "limit-tu": "1",
         "tu-intra-depth": "2",
@@ -57,14 +51,23 @@
         "tskip-fast": "1",
 
         "limit-sao": "1",
-        "sao-non-deblock": "1"
+        "sao-non-deblock": "1",
+        
+        "no-open-gop": "1",
+        "allow-non-conformance": "1",
+        "opt-qp-pps": "1",
+        "opt-ref-list-length-pps": "1"
         }
    },
       {
-      "name": "4:2:0 General purpose, 8-10bit projects (Recommended)",
+      "name": "4:2:0 General purpose, 10bit projects (Recommended)",
       "description": "by iAvoe, require x265 v3.5 since some parameter names are changed; or new parameters added/deleted",
       "options": {
         "_pixelFormat": "yuv420p10le",
+        "preset": "slow",
+        "ctu": "64",
+        "ref": "3",
+        "hash": "2",
         "min-cu-size": "16",
         "limit-tu": "1",
         "tu-intra-depth": "2",
@@ -103,7 +106,12 @@
         "tskip-fast": "1",
 
         "limit-sao": "1",
-        "sao-non-deblock": "1"
+        "sao-non-deblock": "1",
+
+        "no-open-gop": "1",
+        "allow-non-conformance": "1",
+        "opt-qp-pps": "1",
+        "opt-ref-list-length-pps": "1"
         }
    },
    {
@@ -111,6 +119,10 @@
       "description": "by iAvoe",
       "options": {
         "_pixelFormat": "yuv444p",
+        "preset": "slow",
+        "ctu": "64",
+        "ref": "3",
+        "hash": "2",
         "min-cu-size": "16",
         "limit-tu": "1",
         "tu-intra-depth": "2",
@@ -149,14 +161,23 @@
         "tskip-fast": "1",
 
         "limit-sao": "1",
-        "sao-non-deblock": "1"
+        "sao-non-deblock": "1",
+
+        "no-open-gop": "1",
+        "allow-non-conformance": "1",
+        "opt-qp-pps": "1",
+        "opt-ref-list-length-pps": "1"
         }
    },
    {
-      "name": "4:4:4 General purpose, 8-10bit projects (Render & reuse)",
+      "name": "4:4:4 General purpose, 10bit projects (Render & reuse)",
       "description": "by iAvoe",
       "options": {
         "_pixelFormat": "yuv444p10le",
+        "preset": "slow",
+        "ctu": "64",
+        "ref": "3",
+        "hash": "2",
         "min-cu-size": "16",
         "limit-tu": "1",
         "tu-intra-depth": "2",
@@ -195,11 +216,16 @@
         "tskip-fast": "1",
 
         "limit-sao": "1",
-        "sao-non-deblock": "1"
+        "sao-non-deblock": "1",
+
+        "no-open-gop": "1",
+        "allow-non-conformance": "1",
+        "opt-qp-pps": "1",
+        "opt-ref-list-length-pps": "1"
         }
    },
    {
-      "name": "4:2:0 <40000kbps Lossless, 8-10bit projects",
+      "name": "4:2:0 <40000kbps Lossless, 10bit projects",
       "description": "by iAvoe, If clip is going more than 40000kbps, adjust 'b' to higher rates.",
       "options": {
         "_pixelFormat": "yuv420p10le",
@@ -210,7 +236,7 @@
         }
    },
    {
-      "name": "4:4:4 <40000kbps Lossless, 8-10bit projects",
+      "name": "4:4:4 <40000kbps Lossless, 10bit projects",
       "description": "by iAvoe, If clip is going more than 40000kbps, adjust 'b' to higher rates",
       "options": {
         "_pixelFormat": "yuv444p10le",
@@ -221,7 +247,7 @@
       }
    },
    {
-      "name": "4:4:4 Scientific lossless, 8-10bit projects",
+      "name": "4:4:4 Scientific lossless, 10bit projects",
       "description": "by iAvoe",
       "options": {
         "_pixelFormat": "yuv444p10le",
@@ -233,6 +259,10 @@
       "description": "by iAvoe. Missing option: selective-sao, add 'selective-sao 3' at end of this option if libx265 v3.5 gets this option implemented.",
       "options": {
         "_pixelFormat": "yuv420p",
+        "preset": "slow",
+        "ctu": "64",
+        "ref": "3",
+        "hash": "2",
         "min-cu-size": "16",
         "limit-tu": "1",
         "tu-intra-depth": "4",
@@ -283,14 +313,23 @@
 
         "deblock": "0:0",
         "limit-sao": "1",
-        "sao-non-deblock": "1"
+        "sao-non-deblock": "1",
+
+        "no-open-gop": "1",
+        "allow-non-conformance": "1",
+        "opt-qp-pps": "1",
+        "opt-ref-list-length-pps": "1"
         }
    },
    {
-      "name": "4:2:0 High compression, 8-10bit projects (Very slow)",
+      "name": "4:2:0 High compression, 10bit projects (Very slow)",
       "description": "by iAvoe. Missing option: selective-sao, add 'selective-sao 3' at end of this option if libx265 v3.5 gets this option implemented",
       "options": {
         "_pixelFormat": "yuv420p10le",
+        "preset": "slow",
+        "ctu": "64",
+        "ref": "3",
+        "hash": "2",
         "min-cu-size": "16",
         "limit-tu": "1",
         "tu-intra-depth": "4",
@@ -341,7 +380,12 @@
 
         "deblock": "0:0",
         "limit-sao": "1",
-        "sao-non-deblock": "1"
+        "sao-non-deblock": "1",
+
+        "no-open-gop": "1",
+        "allow-non-conformance": "1",
+        "opt-qp-pps": "1",
+        "opt-ref-list-length-pps": "1"
         }
    },
    {
@@ -349,6 +393,10 @@
       "description": "by iAvoe. Missing option: selective-sao, add 'selective-sao 3' at end of this option if libx265 v3.5 gets this option implemented",
       "options": {
         "_pixelFormat": "yuv444p",
+        "preset": "slow",
+        "ctu": "64",
+        "ref": "3",
+        "hash": "2",
         "min-cu-size": "16",
         "limit-tu": "1",
         "tu-intra-depth": "4",
@@ -399,14 +447,23 @@
 
         "deblock": "0:0",
         "limit-sao": "1",
-        "sao-non-deblock": "1"
+        "sao-non-deblock": "1",
+
+        "no-open-gop": "1",
+        "allow-non-conformance": "1",
+        "opt-qp-pps": "1",
+        "opt-ref-list-length-pps": "1"
         }
      },
      {
-      "name": "4:4:4 High compression, 8-10bit projects (Very slow)",
+      "name": "4:4:4 High compression, 10bit projects (Very slow)",
       "description": "by iAvoe. Missing option: selective-sao, add 'selective-sao 3' at end of this option if libx265 v3.5 gets this option implemented",
       "options": {
         "_pixelFormat": "yuv444p10le",
+        "preset": "slow",
+        "ctu": "64",
+        "ref": "3",
+        "hash": "2",
         "min-cu-size": "16",
         "limit-tu": "1",
         "tu-intra-depth": "4",
@@ -457,14 +514,23 @@
 
         "deblock": "0:0",
         "limit-sao": "1",
-        "sao-non-deblock": "1"
+        "sao-non-deblock": "1",
+
+        "no-open-gop": "1",
+        "allow-non-conformance": "1",
+        "opt-qp-pps": "1",
+        "opt-ref-list-length-pps": "1"
         }
    },
    {
-      "name": "4:2:0 Anime +quality, 8-10bit projects (Very slow)",
+      "name": "4:2:0 Anime +quality, 10bit projects (Very slow)",
       "description": "by iAvoe",
       "options": {
         "_pixelFormat": "yuv420p10le",
+        "preset": "slow",
+        "ctu": "64",
+        "ref": "3",
+        "hash": "2",
         "min-cu-size": "8",
         "limit-tu": "1",
         "tu-intra-depth": "4",
@@ -517,14 +583,23 @@
 
         "limit-sao": "1",
         "sao-non-deblock": "1",
-        "single-sei": "1"
+        "single-sei": "1",
+
+        "no-open-gop": "1",
+        "allow-non-conformance": "1",
+        "opt-qp-pps": "1",
+        "opt-ref-list-length-pps": "1"
         }
     },
     {
-      "name": "4:4:4 Anime +quality, 8-10bit projects (Very slow)",
+      "name": "4:4:4 Anime +quality, 10bit projects (Very slow)",
       "description": "by iAvoe",
       "options": {
         "_pixelFormat": "yuv444p10le",
+        "preset": "slow",
+        "ctu": "64",
+        "ref": "3",
+        "hash": "2",
         "min-cu-size": "8",
         "limit-tu": "1",
         "tu-intra-depth": "4",
@@ -577,14 +652,23 @@
 
         "limit-sao": "1",
         "sao-non-deblock": "1",
-        "single-sei": "1"
+        "single-sei": "1",
+
+        "no-open-gop": "1",
+        "allow-non-conformance": "1",
+        "opt-qp-pps": "1",
+        "opt-ref-list-length-pps": "1"
         }
     },
     {
-      "name": "4:2:0 Anime BDRip Coldwar, 8-10bit projects (Very slow)",
+      "name": "4:2:0 Anime BDRip Coldwar, 10bit projects (Very slow)",
       "description": "by iAvoe, an unwritten rule requires 4~5x zoom in dark scene must look very similar to source, Ripper who achieves this gets the most downloads, some compression methods disabled, may confuse the hell out of x264-5 devs. I personally don't like this as well",
       "options": {
         "_pixelFormat": "yuv420p10le",
+        "preset": "slow",
+        "ctu": "64",
+        "ref": "3",
+        "hash": "2",
         "min-cu-size": "8",
         "limit-tu": "0",
         "tu-intra-depth": "4",
@@ -640,14 +724,23 @@
         "deblock": "0:0",
 
         "no-sao": "1",
-        "single-sei": "1"
+        "single-sei": "1",
+
+        "no-open-gop": "1",
+        "allow-non-conformance": "1",
+        "opt-qp-pps": "1",
+        "opt-ref-list-length-pps": "1"
         }
     },
     {
-      "name": "4:4:4 Anime BDRip Coldwar, 8-10bit projects (Very slow)",
+      "name": "4:4:4 Anime BDRip Coldwar, 10bit projects (Very slow)",
       "description": "by iAvoe",
       "options": {
         "_pixelFormat": "yuv444p10le",
+        "preset": "slow",
+        "ctu": "64",
+        "ref": "3",
+        "hash": "2",
         "min-cu-size": "8",
         "limit-tu": "0",
         "tu-intra-depth": "4",
@@ -703,12 +796,18 @@
         "deblock": "0:0",
 
         "no-sao": "1",
-        "single-sei": "1"
+        "single-sei": "1",
+
+        "no-open-gop": "1",
+        "allow-non-conformance": "1",
+        "opt-qp-pps": "1",
+        "opt-ref-list-length-pps": "1"
         }
   }
   ],
   "parameterGroups": {
     "x265-params": [
+      "allow-non-conformance",
       "interlace",
       "lossless",
       "ssim",


### PR DESCRIPTION
I've used VSCode and edited those 2 files, and made sure the json format was correct and all parameters are linked to the definitions in the bottom part of file.
However due to I've mainly worked with x265.exe instead of libx265, some parameters are missing in libx265 and I cannot gurantee they actually will work (some parameter may get deleted or the definitions needs to be modified if libx265 v3.5 persists not recognizing)
Software is not my profession and I wish I could compile and test the changes myself. Someone needs to compile and check in software to see if the parameters are applied correctly.
Changes also happened in x264 parameters, they have been separated with color profiles (4:2:0 and 4:4:4) thus creates more versions, just 1 version needs to be tested for them.